### PR TITLE
Replaces ipython notebook execution with nbconvert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,3 +225,6 @@ pip-selfcheck.json
 # Temporal folders
 coverage-reports/
 tmp/
+
+# Notebooks
+.ipynb_checkpoints

--- a/nb2report/cell_utils.py
+++ b/nb2report/cell_utils.py
@@ -21,10 +21,7 @@ def assert_cell(cell):
     bool
         True if fits into the ipython notebook cell structure.
     """
-    _is_cell =\
-        isinstance(cell, dict)\
-        and 'cell_type' in cell and isinstance(cell['cell_type'], str)\
-        and 'source' in cell and isinstance(cell['source'], list)
+    _is_cell = 'cell_type' in cell and isinstance(cell['cell_type'], str)
 
     if not _is_cell:
         raise AssertionError('Wrong cell format.'
@@ -53,7 +50,7 @@ def is_assert(cell):
         True it is an assert cell. False otherwise.
     """
     try:
-        return assert_cell(cell) and '# asserts' in cell['source'][0].lower()
+        return assert_cell(cell) and '# asserts' in cell['source'].lower()
     except IndexError:
         return False
 
@@ -155,18 +152,20 @@ def get_first_line(cell):
         raise IndexError('Cell source is empty. %s' % e)
 
 
-def get_code(cell):
-    """ Get all the code from the source field.
+def get_output(cell):
+    """ Get the plain text output from the source field.
 
     Parameters
     ----------
-    cell: dict
-        iPython notebook cell representation.
+    cell: NotebookNode
+        A json-like object representing a notebook cell.
 
     Returns
     -------
     str
-        All the code from the source field.
+        Output from the source field.
     """
-    if is_code(cell):
-        return ''.join(cell['source'])
+    if is_code(cell) and cell['outputs']:
+        return cell['outputs'][0]['data'].get('text/plain', 'False')
+    else:
+        return 'False'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ ipython-genutils==0.2.0
 Jinja2==2.10.3
 numpy==1.17.4 # https://github.com/ipython/ipykernel/issues/397
 click==7.0
+nbconvert==5.6.1
+ipykernel

--- a/tests/resources/dummy_assert_false.ipynb
+++ b/tests/resources/dummy_assert_false.ipynb
@@ -23,19 +23,36 @@
    ]
   },
   {
+   "source": [
+    "True == True"
+   ],
    "cell_type": "code",
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "True"
+     },
+     "metadata": {},
+     "execution_count": 1
+    }
+   ],
    "metadata": {},
-   "source": ["True == True"]
+   "execution_count": 1
   },
   {
    "cell_type": "code",
    "metadata": {},
-   "source": ["True == False"]
+   "source": [
+    "True == False"
+   ]
   },
   {
    "cell_type": "code",
    "metadata": {},
-   "source": ["True == True"]
+   "source": [
+    "True == True"
+   ]
   }
  ],
  "metadata": {
@@ -54,7 +71,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/tests/resources/dummy_assert_true.ipynb
+++ b/tests/resources/dummy_assert_true.ipynb
@@ -15,7 +15,9 @@
   },
   {
    "cell_type": "markdown",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Asserts\n",
     "\n",
@@ -24,13 +26,12 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
-   "source": ["True == True"]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": ["True == True"]
+   "outputs": [],
+   "source": [
+    "True == True"
+   ]
   }
  ],
  "metadata": {
@@ -49,7 +50,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.5-final"
   }
  },
  "nbformat": 4,

--- a/tests/test_cell_utils.py
+++ b/tests/test_cell_utils.py
@@ -27,13 +27,13 @@ def test_not_assert_is_cell():
 
 
 def test_is_assert():
-    cell1 = {'cell_type': 'whatever', 'source': ['# asserts']}
-    cell2 = {'cell_type': 'whatever', 'source': ['# AssertS']}
-    cell3 = {'cell_type': 'whatever', 'source': ['--_-# assertsaaaA']}
-    cell4 = {'cell_type': 'whatever', 'source': ['--_-# AsSErtsaaaA']}
-    cell5 = {'cell_type': 'whatever', 'source': ['# ', '# asserts']}
-    cell6 = {'cell_type': 'whatever', 'source': ['']}
-    cell7 = {'cell_type': 'whatever', 'source': []}
+    cell1 = {'cell_type': 'whatever', 'source': '# asserts'}
+    cell2 = {'cell_type': 'whatever', 'source': '# AssertS'}
+    cell3 = {'cell_type': 'whatever', 'source': '--_-# assertsaaaA'}
+    cell4 = {'cell_type': 'whatever', 'source': '--_-# AsSErtsaaaA'}
+    cell5 = {'cell_type': 'whatever', 'source': '# '}
+    cell6 = {'cell_type': 'whatever', 'source': ''}
+    cell7 = {'cell_type': 'whatever', 'source': 'gsfdgsa'}
 
     assert is_assert(cell1) is True
     assert is_assert(cell2) is True
@@ -104,7 +104,27 @@ def test_get_first_line():
     assert get_first_line(cell) == 'whatever'
 
 
-def test_get_code():
-    cell = {'cell_type': 'code', 'source': ['whatever', 'no']}
+def test_get_output():
+    cell1 = {
+        'cell_type': 'code',
+        'execution_count': 3,
+        'metadata': {},
+        'outputs': [
+            {'data': {'text/plain': 'True'},
+            'execution_count': 3,
+            'metadata': {},
+            'output_type': 'execute_result'}
+            ],
+        'source': ['True == True']
+        }
 
-    assert get_code(cell) == 'whateverno'
+    cell2 = {
+        'cell_type': 'code',
+        'execution_count': 3,
+        'metadata': {},
+        'outputs': [],
+        'source': ['True == True']
+        }
+
+    assert get_output(cell1) == 'True'
+    assert get_output(cell2) == 'False'

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,5 +1,6 @@
 import pytest
 import os
+import nbformat
 
 from pathlib import Path
 from nb2report import reporting
@@ -54,7 +55,7 @@ def test__add_report():
 def test__load_notebook():
     # schema file is not an output notebook but it is a notebook
     # it should read it anyway
-    assert isinstance(reporting._load_notebook(EMPTY_NOTEBOOK), dict)
+    assert isinstance(reporting._load_notebook(EMPTY_NOTEBOOK), nbformat.notebooknode.NotebookNode)
 
 
 def test__get_assert_cell_index():
@@ -71,10 +72,9 @@ def test__get_assert_cell_index():
         {
             "cell_type": "markdown",
             "metadata": {},
-            "source": ["# Asserts\n",
-                       "\n",
+            "source": "# Asserts\n"
+                       "\n"
                        "Note: automatic tests will check all asserts to be true"
-                       ]
         }
     ]
 
@@ -93,28 +93,6 @@ def test__get_assert_cell_index_empty_cell():
     ]
 
     reporting._get_assert_cell_index(cells)
-
-
-def test__clean_output():
-    assert reporting._clean_output("Out[1]: True\n") == "True"
-    assert reporting._clean_output("Out[1123]: hola") == "hola"
-    assert reporting._clean_output("OuT[9874]:     True") == "True"
-    assert reporting._clean_output("HolaQueTal[0546]:    True\n") == "True"
-
-
-def test__get_interpreter():
-    reporting.IPYTHON_INTERPRETER = None
-    assert reporting.IPYTHON_INTERPRETER is None
-
-    reporting._get_interpreter()
-    assert reporting.IPYTHON_INTERPRETER
-
-
-def test__run_cell():
-    assert reporting._run_cell("print('HOLA')") == 'HOLA'
-    assert reporting._run_cell("") == ''
-    assert reporting._run_cell("1 < 2") == 'True'
-    assert reporting._run_cell("1 > 2") == 'False'
 
 
 def test__evaluate_output():


### PR DESCRIPTION
* get_code has been replaced in order to get the clean output
* removed ipython cell execution and evaluation functions
* added nbconvert as the main method of notebook execution
* added new requirements regarding nbconvert module addition
* Modified affected tests to comply with nbconvert
* ipython tests removed